### PR TITLE
[feat] proxy api

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,2 +1,3 @@
-NEXT_PUBLIC_PERPAGE=5
-NEXT_PUBLIC_API="https://wax.api.atomicassets.io"
+NEXT_PUBLIC_PERPAGE=8
+API="https://wax.api.atomicassets.io"
+IMG_API="https://ipfs.atomichub.io/ipfs/"

--- a/src/components/layout/Card/index.tsx
+++ b/src/components/layout/Card/index.tsx
@@ -16,7 +16,7 @@ const Card = (props: CardProps) => {
 
 	return (
 		<styled.Container>
-			<styled.Image skeleton={props.loading} src={`https://ipfs.atomichub.io/ipfs/${props.asset?.data?.img}`} />
+			<styled.Image skeleton={props.loading} src={`api/img/${props.asset?.data?.img}`} />
 
 			<div>
 				<p>

--- a/src/pages/api/assets.ts
+++ b/src/pages/api/assets.ts
@@ -1,0 +1,7 @@
+import axios from "axios"
+
+export default async function handler (req, res) {
+	const { data } = await axios(`${process.env.API}/atomicassets/v1/assets`, { params: req.query })
+
+	res.status(200).json(data)
+}

--- a/src/pages/api/img/[id].ts
+++ b/src/pages/api/img/[id].ts
@@ -1,0 +1,10 @@
+import http from "http"
+import axios from "axios"
+
+export default async function handler (req, res: http.ServerResponse) {
+	const { data, headers } = await axios(`${process.env.IMG_API}${req.query.id}`, { responseType: "arraybuffer" })
+
+	Object.entries(headers).forEach(entry => res.setHeader(...entry))
+	res.write(data)
+	res.end()
+}

--- a/src/store/models/assets/slice.ts
+++ b/src/store/models/assets/slice.ts
@@ -26,7 +26,7 @@ const useAssetSlice = createStore((set: any, get: any) => ({
 		set(() => ({ loading: true }))
 
 		const { limit, page, order, sort } = (get() as State).list
-		const { data } = await request("atomicassets/v1/assets", { params: { limit, page, order, sort } })
+		const { data } = await request("api/assets", { params: { limit, page, order, sort } })
 
 		set((state: State) => ({
 			loading: false,

--- a/src/utils/request.ts
+++ b/src/utils/request.ts
@@ -1,8 +1,6 @@
 // Packages
 import axios from "axios"
 
-const request = axios.create({
-	baseURL: process.env.NEXT_PUBLIC_API
-})
+const request = axios.create({})
 
 export default request


### PR DESCRIPTION
# Summary

Moved all the requests to pipe through the Next API so we can proxy it for performance and safety.

# Changes

- removed endpoints reference in the frontend
- added assets and img endpoint to next

# References
- [next api](https://nextjs.org/docs/api-routes/introduction)